### PR TITLE
Put upper bounds on dependencies

### DIFF
--- a/haskdeep.cabal
+++ b/haskdeep.cabal
@@ -51,9 +51,8 @@ description:
   Heavily inspired by @hashdeep@: <http://md5deep.sourceforge.net/>
 
 category:           Console, Cryptography, System
-extra-source-files:
-  CHANGELOG.md
-  README.md
+extra-source-files: README.md
+extra-doc-files:    CHANGELOG.md
 
 executable haskdeep
   hs-source-dirs:   src
@@ -69,18 +68,18 @@ executable haskdeep
     Options
 
   build-depends:
-    , attoparsec            >=0.13
+    , attoparsec            >=0.13  && <0.15
     , base                  >=4.13  && <4.19
     , base16-bytestring     >=1.0   && <1.1
     , bytestring            >=0.9   && <1.0
-    , cereal                >=0.5
+    , cereal                >=0.5   && <0.6
     , conduit               >=1.3   && <1.4
     , conduit-extra         >=1.3   && <1.4
     , containers            >=0.6   && <0.7
     , crypto-api            >=0.13  && <0.14
     , crypto-conduit        ==0.5.6
     , cryptohash-cryptoapi  >=0.1   && <0.2
-    , cryptonite            >=0.20
+    , cryptonite            >=0.20  && <0.31
     , directory             >=1.3   && <1.4
     , filepath              >=1.4   && <1.5
     , optparse-applicative  >=0.16  && <0.18


### PR DESCRIPTION
- otherwise `cabal check` barks